### PR TITLE
feat: pops can be extended through their functor

### DIFF
--- a/POP.nix
+++ b/POP.nix
@@ -222,7 +222,29 @@
     computePrecedenceList = c3ComputePrecedenceList;
     mergeInstance = mergeAttrset;
     bottomInstance = {};
-    topProto = __meta__: self: super: super // {inherit __meta__;};
+    topProto = __meta__: self: super:
+      super
+      // {
+        inherit __meta__;
+        __functor = self: extension:
+          pop {
+            name = self.__meta__.name;
+            supers = [self];
+            /*
+             The argument passed to the functor can be:
+              - just an attrset,
+              - a function asking for self
+              - a function asking for self and super
+             */
+            extension = self: super:
+              if builtins.isFunction extension
+              then
+                if builtins.isFunction (extension self)
+                then extension self super
+                else extension self
+              else extension;
+          };
+      };
     getSupers = {supers ? [], ...}: supers;
     getPrecedenceList = p:
       if p ? __meta__
@@ -353,5 +375,5 @@
 
   # Turn a pop into a normal attrset by erasing its `__meta__` information.
   # unpop :: Pop A B -> A
-  unpop = p: builtins.removeAttrs p ["__meta__"];
+  unpop = p: builtins.removeAttrs p ["__meta__" "__functor"];
 }

--- a/checks.nix
+++ b/checks.nix
@@ -19,7 +19,7 @@
           c = 3;
         };
       });
-      expected = ["__meta__" "a" "b" "c"];
+      expected = ["__functor" "__meta__" "a" "b" "c"];
     };
     testInstantiation = {
       expr = unpop (pop {
@@ -50,6 +50,20 @@
         list4IsNonEmpty = true;
         testRemoveEmpties = [[1] [2 3] [4 [] 5] [6]];
         testRemoveNext = [[2 3 4] [2 5] [6 7] [3 6] [8]];
+      };
+    };
+    testFunctor = {
+      expr = let
+        a = pop {defaults.m = 0;};
+        b = a {
+          m = 1;
+          n = 5;
+        };
+      in
+        unpop b;
+      expected = {
+        m = 1;
+        n = 5;
       };
     };
 


### PR DESCRIPTION
This makes pops work similarly to jsonnet objects. Extending a pop is much easier. You just call the pop with the attribute set to extend it with.

The `__functor` I added has some magic, where it can detect if you just pass it an attrset, a function with one argument, or two arguments and pass arguments appropriately. I think this makes the process of updating pops more elegant. Without it though, I think we could just force the argument passed to the functor be an Extension.

```
p = pop { defaults.a = 0; }
p { a = 1; }
p (self: { a = 1; b = self.b; })
p (self: super: { a = super.a + 1; b = self.a; })
```